### PR TITLE
Add actual example ruby files and file structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.2
+ - File structure and code was added to have the repo more accuretly reflect the custom codec tutorial: https://www.elastic.co/guide/en/logstash/current/_how_to_write_a_logstash_codec_plugin.html
+
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,13 @@
+The following is a list of people who have contributed ideas, code, bug
+reports, or in general have helped logstash along its way.
+
+Contributors:
+* Aaron Mildenstein (untergeek)
+* Pier-Hugues Pellerin (ph)
+* Shaunak Kashyap (ycombinator)
+* Pere Urbón (purbon)
+
+Note: If you've sent us patches, bug reports, or otherwise contributed to
+Logstash, and you aren't on the list above and want to be, please let us know
+and we'll make sure you're here. Contributions from folks like you are what make
+open source awesome.

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gemspec
+
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+@files=[]
+
+task :default do
+  system("rake -T")
+end
+
+require "logstash/devutils/rake"

--- a/lib/logstash/codecs/example.rb
+++ b/lib/logstash/codecs/example.rb
@@ -1,0 +1,47 @@
+# encoding: utf-8
+require "logstash/codecs/base"
+require "logstash/codecs/line"
+require "logstash/namespace"
+
+# Add any asciidoc formatted documentation here
+class LogStash::Codecs::Example < LogStash::Codecs::Base
+
+  # This example codec will append a string to the message field
+  # of an event, either in the decoding or encoding methods
+  #
+  # This is only intended to be used as an example.
+  #
+  # input {
+  #   stdin { codec => example }
+  # }
+  #
+  # or
+  #
+  # output {
+  #   stdout { codec => example }
+  # }
+  config_name "example"
+
+  # Append a string to the message
+  config :append, :validate => :string, :default => ', Hello World!'
+
+  public
+  def register
+    @lines = LogStash::Codecs::Line.new
+    @lines.charset = "UTF-8"
+  end
+
+  public
+  def decode(data)
+    @lines.decode(data) do |line|
+      replace = { "message" => line["message"].to_s + @append }
+      yield LogStash::Event.new(replace)
+    end
+  end # def decode
+
+  public
+  def encode(event)
+    @on_event.call(event, event["message"].to_s + @append + NL)
+  end # def encode
+
+end # class LogStash::Codecs::Example

--- a/logstash-codec-example.gemspec
+++ b/logstash-codec-example.gemspec
@@ -1,0 +1,26 @@
+Gem::Specification.new do |s|
+  s.name = 'logstash-codec-example'
+  s.version = '0.1.0'
+  s.licenses = ['Apache License (2.0)']
+  s.summary = "This codec does x, y, z in Logstash"
+  s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
+  s.authors = ["Elastic"]
+  s.email = 'info@elastic.co'
+  s.homepage = "http://www.elastic.co/guide/en/logstash/current/index.html"
+  s.require_paths = ["lib"]
+
+  # Files
+  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
+   # Tests
+  s.test_files = s.files.grep(%r{^(test|spec|features)/})
+
+  # Special flag to let us know this is actually a logstash plugin
+  s.metadata = { "logstash_plugin" => "true", "logstash_group" => "codec" }
+
+  # Gem dependencies
+  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
+
+  s.add_runtime_dependency 'logstash-codec-line', '>= 2.1.0'
+
+  s.add_development_dependency 'logstash-devutils'
+end

--- a/logstash-codec-example.gemspec
+++ b/logstash-codec-example.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-codec-example'
-  s.version = '0.1.0'
+  s.version = '2.2.2'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This codec does x, y, z in Logstash"
   s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/codecs/example_spec.rb
+++ b/spec/codecs/example_spec.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+require "logstash/devutils/rspec/spec_helper"
+require "logstash/codecs/example"
+
+
+describe LogStash::Codecs::Example do
+
+  subject do
+    LogStash::Codecs::Example.new
+  end
+
+  it "should append a string to data" do
+    data = "Test\n"
+    subject.decode(data) do |event|
+      puts event["message"]
+      expect(event["message"]).to eq("Test, Hello World!")
+    end
+  end
+end


### PR DESCRIPTION
This adds (and fixes in a few places) the example documents listed in https://www.elastic.co/guide/en/logstash/current/_how_to_write_a_logstash_codec_plugin.html to the actual repo it references.
